### PR TITLE
Added an iterator method to the DjangoCassandraQuerySet class.  Also …

### DIFF
--- a/django_cassandra_engine/models/__init__.py
+++ b/django_cassandra_engine/models/__init__.py
@@ -741,6 +741,9 @@ class DjangoCassandraQuerySet(query.ModelQuerySet):
         conditions = []
         for col in colnames:
             try:
+                if hasattr(col, 'resolve_expression'):
+                    warnings.warn('Sorting by Django DB Expressions is not supported')
+                    continue
                 conditions.append('"{0}" {1}'.format(
                     *self._get_ordering_condition(col))
                 )
@@ -781,6 +784,9 @@ class DjangoCassandraQuerySet(query.ModelQuerySet):
 
     def _clone(self):
         return copy.deepcopy(self)
+    
+    def iterator(self, *args, **kwargs):
+        return super(query.ModelQuerySet, self).all()
 
 
 class DjangoCassandraModel(


### PR DESCRIPTION
…added a check in the order_by method of the DjangoCassandraQuerySet class so instead of an exception, a warning is thrown when a the order_by method is called with django expressions instead of str column names.  These two changes all me use use django-cassandra-engine with django-elasticsearch-dsl relatively seemlessly.